### PR TITLE
explicitly open file as utf8

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ In addition, sometimes single-letter numerals are spelled out in full. For such 
 2. Use a YAML library to load `hebrew-special-numbers/styles/default.yml` into an associative array. For example, in Python (with the `pyyaml` package installed):
     ```python
     import yaml
-    hsn = yaml.load(open('hebrew-special-numbers/styles/default.yml'))
+    hsn = yaml.load(open('hebrew-special-numbers/styles/default.yml', encoding="utf8"))
     ```
 
 3. Optional: It is possible to create styles by cascading styles on top of each other. Load in any additional styles and recursively merge them into your associative array. This may require defining a recursive `merge` function.
     ```python
     # using merge() by Andrew Cooke, http://stackoverflow.com/a/7205107
-    chaipower = yaml.load(open('hebrew-special-numbers/styles/chaipower.yml'))
+    chaipower = yaml.load(open('hebrew-special-numbers/styles/chaipower.yml', encoding="utf8"))
     hsn = merge(hsn, chaipower)
     ```
 

--- a/test/test_default.py
+++ b/test/test_default.py
@@ -25,7 +25,7 @@ import unittest
 from os import path
 import yaml  # requires `pip install pyyaml`
 proj_dir = path.dirname(path.dirname(path.realpath(__file__)))
-hsn = yaml.load(open(path.join(proj_dir, 'styles/default.yml')))
+hsn = yaml.load(open(path.join(proj_dir, 'styles/default.yml'), encoding="utf8"))
 
 
 def hebrew_numeral(val, gershayim=True):


### PR DESCRIPTION
otherwise, on windows at least, it assumes cp1252 and PyYAML fails to read it